### PR TITLE
Release 1.0.1

### DIFF
--- a/1/Dockerfile
+++ b/1/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.5-buster
+FROM python:3.9.6-buster
 
 COPY release_version.py /plugin_script/release_version.py
 COPY requirements.txt /plugin_script/requirements.txt

--- a/1/release_version.py
+++ b/1/release_version.py
@@ -27,6 +27,7 @@ class GitHub:
         return response
 
     def add_release(self, tag: str, branch: str, title: str, content: str, pre_release: bool):
+        print(f"Creating GitHub {'pre-' if pre_release else ''}release {title} ({tag} tag).")
         self.post(
             "/releases",
             {
@@ -64,7 +65,7 @@ def create_github_release():
 def get_latest_version() -> dict:
     changelog_path = os.getenv('PLUGIN_CHANGELOG_PATH', "CHANGELOG.md")
     releases = keepachangelog.to_raw_dict(changelog_path)
-    new_version = sorted(releases.keys())[-1]
+    new_version, _ = keepachangelog.to_sorted_semantic(releases.keys())[-1]
     return releases[new_version]
 
 

--- a/1/requirements.txt
+++ b/1/requirements.txt
@@ -1,2 +1,2 @@
-keepachangelog==2.0.0.dev1
-requests==2.25.1
+keepachangelog==2.0.0.dev2
+requests==2.26.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2021-08-04
+### Fixed
+- Releases can now to be performed even if previous versions do not have the same number of digits.
+
+### Added
+- Log the release title and tag that will be created.
+
 ## [1.0.0] - 2021-05-28
 ### Changed
 - Add technical information to the release content such as actual release time.
@@ -60,7 +67,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
-[Unreleased]: https://github.com/ets-infra/drone-github-release/compare/1.0.0...master
+[Unreleased]: https://github.com/ets-infra/drone-github-release/compare/1.0.1...master
+[1.0.1]: https://github.com/ets-infra/drone-github-release/compare/1.0.0...1.0.1
 [1.0.0]: https://github.com/ets-infra/drone-github-release/compare/0.6.0...1.0.0
 [0.6.0]: https://github.com/ets-infra/drone-github-release/compare/0.5.0...0.6.0
 [0.5.0]: https://github.com/ets-infra/drone-github-release/compare/0.4.0...0.5.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Supported tags and respective Dockerfile links
 
-- [`1.0.0`, `latest`](https://github.com/ets-infra/drone-github-release/blob/master/1/Dockerfile)
+- [`1.0.1`, `latest`](https://github.com/ets-infra/drone-github-release/blob/master/1/Dockerfile)
 
 # Quick reference (cont.)
 


### PR DESCRIPTION
### Fixed
- Releases can now to be performed even if previous versions do not have the same number of digits.

### Added
- Log the release title and tag that will be created.
